### PR TITLE
Update LLM Library to Latest OpenAI GPT-5 model with README Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ parser = StructuredPDFParser(
     # VLM Settings
     use_vlm=True,
     vlm_provider="openai",
-    vlm_model="gpt-4o",
+    vlm_model="gpt-5",
     vlm_api_key="your_api_key",
     
     # Layout Detection Settings
@@ -150,7 +150,7 @@ parser = ChartTablePDFParser(
     # VLM Settings
     use_vlm=True,
     vlm_provider="openai",
-    vlm_model="gpt-4o",
+    vlm_model="gpt-5",
     vlm_api_key="your_api_key",
     
     # Layout Detection Settings
@@ -289,7 +289,7 @@ parser = StructuredPDFParser(
     use_vlm=True,
     vlm_provider="openai",
     vlm_api_key="your_openai_api_key",
-    vlm__model="gpt-4o",
+    vlm__model="gpt-5",
     layout_model_name="PP-DocLayout_plus-L",
     dpi=300,  # Higher DPI for better quality
     min_score=0.5,  # Higher confidence threshold
@@ -367,4 +367,4 @@ parser.display_pages_with_boxes("document.pdf")
 - **Pandas**: Data manipulation
 - **OpenPyXL**: Excel file generation
 - **Google Generative AI**: For Gemini VLM integration
-- **OpenAI**: For GPT-4 VLM integration
+- **OpenAI**: For GPT-5 VLM integration

--- a/doctra/cli/main.py
+++ b/doctra/cli/main.py
@@ -818,8 +818,8 @@ def info():
 
     # VLM providers
     click.echo("\nVLM Providers:")
-    click.echo("  • Gemini (Google) - gemini-1.5-flash-latest, gemini-1.5-pro")
-    click.echo("  • OpenAI - gpt-4o, gpt-4o-mini, gpt-4-vision-preview")
+    click.echo("  • Gemini (Google) - gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.0-flash")
+    click.echo("  • OpenAI - gpt-5, gpt-5-mini, gpt-4.1, gpt-4.1-mini, gpt-4o")
 
     # Available layout models
     click.echo("\nLayout Detection Models:")


### PR DESCRIPTION
This merge request updates the README file to reflect the library’s use of OpenAI’s GPT-5 model, following the LLM update in the merged `feature/update_llms` branch. The change ensures the documentation accurately references GPT-5 instead of the previous OpenAI model.

**Changes**:
- Updated README.md to replace references to the previous OpenAI model with GPT-5.
- Ensured the README aligns with the library’s current configuration, which uses GPT-5 and Google Gemini 2.5.

**Motivation**:
- The README update ensures users are informed about the adoption of GPT-5, which was integrated in the previous merge request.
- Maintains consistency between the codebase and documentation for better user experience.