### PR TITLE
Add OpenRouter as VLM Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ parser = StructuredPDFParser()
 # Parser with VLM for structured data extraction
 parser = StructuredPDFParser(
     use_vlm=True,
-    vlm_provider="openai",  # or "gemini" or "anthropic"
+    vlm_provider="openai",  # or "gemini" or "anthropic" or "openrouter"
     vlm_api_key="your_api_key_here"
 )
 

--- a/doctra/engines/vlm/provider.py
+++ b/doctra/engines/vlm/provider.py
@@ -20,7 +20,7 @@ def make_model(
     """
     Build a callable Outlines model for VLM processing.
     
-    Creates an Outlines model instance configured for Gemini, OpenAI, or Anthropic
+    Creates an Outlines model instance configured for Gemini, OpenAI, Anthropic, or OpenRouter
     providers. Only one backend is active at a time, with Gemini as the default.
 
     :param vlm_provider: VLM provider to use ("gemini", "openai", or "anthropic", default: "gemini")
@@ -39,6 +39,8 @@ def make_model(
             vlm_model = "gpt-5"
         elif vlm_provider == "anthropic":
             vlm_model = "claude-opus-4-1"
+        elif vlm_provider == "openrouter":
+            vlm_model = "x-ai/grok-4"
 
     if vlm_provider == "gemini":
         if not api_key:
@@ -66,6 +68,19 @@ def make_model(
         return outlines.from_anthropic(
             client,
             vlm_model,
+        )
+
+    if vlm_provider == "openrouter":
+        if not api_key:
+            raise ValueError("OpenRouter provider requires api_key to be passed to make_model(...).")
+        # Create the Anthropic client and model (exactly like your snippet)
+        client = openai.OpenAI(
+            base_url="https://openrouter.ai/api/v1",
+            api_key=api_key,
+        )
+        return outlines.from_openai(
+            client,
+            vlm_model
         )
 
     raise ValueError(f"Unsupported provider: {vlm_provider}. Use 'gemini', 'openai', or 'anthropic'.")

--- a/doctra/engines/vlm/service.py
+++ b/doctra/engines/vlm/service.py
@@ -37,7 +37,7 @@ class VLMStructuredExtractor:
         Sets up the VLM model and debug settings for structured data extraction
         from images.
 
-        :param vlm_provider: VLM provider to use ("gemini", "openai", or "anthropic", default: "gemini")
+        :param vlm_provider: VLM provider to use ("gemini", "openai", "anthropic", or "openrouter", default: "gemini")
         :param vlm_model: Model name to use (defaults to provider-specific defaults)
         :param api_key: API key for the VLM provider (required for all providers)
         :param debug: Whether to enable debug output for error handling (default: True)

--- a/doctra/parsers/structured_pdf_parser.py
+++ b/doctra/parsers/structured_pdf_parser.py
@@ -32,7 +32,7 @@ class StructuredPDFParser:
     converting visual elements into structured data.
 
     :param use_vlm: Whether to use VLM for structured data extraction (default: False)
-    :param vlm_provider: VLM provider to use ("gemini", "openai", or "anthropic", default: "gemini")
+    :param vlm_provider: VLM provider to use ("gemini", "openai", "anthropic", or "openrouter", default: "gemini")
     :param vlm_model: Model name to use (defaults to provider-specific defaults)
     :param vlm_api_key: API key for VLM provider (required if use_vlm is True)
     :param layout_model_name: Layout detection model name (default: "PP-DocLayout_plus-L")
@@ -68,7 +68,7 @@ class StructuredPDFParser:
         the VLM service for comprehensive document processing.
 
         :param use_vlm: Whether to use VLM for structured data extraction
-        :param vlm_provider: VLM provider to use ("gemini", "openai", or "anthropic")
+        :param vlm_provider: VLM provider to use ("gemini", "openai", "anthropic", or "openrouter")
         :param vlm_model: Model name to use (defaults to provider-specific defaults)
         :param vlm_api_key: API key for VLM provider
         :param layout_model_name: Layout detection model name

--- a/doctra/parsers/table_chart_extractor.py
+++ b/doctra/parsers/table_chart_extractor.py
@@ -36,7 +36,7 @@ class ChartTablePDFParser:
     :param extract_charts: Whether to extract charts from the document (default: True)
     :param extract_tables: Whether to extract tables from the document (default: True)
     :param use_vlm: Whether to use VLM for structured data extraction (default: False)
-    :param vlm_provider: VLM provider to use ("gemini", "openai", or "anthropic", default: "gemini")
+    :param vlm_provider: VLM provider to use ("gemini", "openai", "anthropic", or "openrouter", default: "gemini")
     :param vlm_model: Model name to use (defaults to provider-specific defaults)
     :param vlm_api_key: API key for VLM provider (required if use_vlm is True)
     :param layout_model_name: Layout detection model name (default: "PP-DocLayout_plus-L")
@@ -66,7 +66,7 @@ class ChartTablePDFParser:
         :param extract_charts: Whether to extract charts from the document
         :param extract_tables: Whether to extract tables from the document
         :param use_vlm: Whether to use VLM for structured data extraction
-        :param vlm_provider: VLM provider to use ("gemini", "openai", or "anthropic")
+        :param vlm_provider: VLM provider to use ("gemini", "openai", "anthropic", or "openrouter")
         :param vlm_model: Model name to use (defaults to provider-specific defaults)
         :param vlm_api_key: API key for VLM provider
         :param layout_model_name: Layout detection model name


### PR DESCRIPTION
This merge request enhances the Vision Language Model (VLM) by adding OpenRouter as a new provider, complementing existing support for OpenAI, Gemini, and Anthropic. The integration enables the library to leverage OpenRouter’s capabilities, improving flexibility for users processing visual and textual data.

**Changes**:
- Added OpenRouter API support to the VLM module.
- Updated the model selection logic to include OpenRouter as an option alongside OpenAI, Gemini and OpenRouter.

**Motivation**:
- Adding OpenRouter expands the VLM’s provider ecosystem, offering users access to its advanced vision-language processing capabilities.
- Aligns with the project’s goal of supporting diverse AI technologies for multimodal tasks.