### PR TITLE
Fix table/chart progress bars to display at full width in notebooks

### DIFF
--- a/doctra/utils/progress.py
+++ b/doctra/utils/progress.py
@@ -429,8 +429,21 @@ def create_notebook_friendly_bar(
         **kwargs
     }
     
-    # Use regular tqdm instead of tqdm_auto to avoid interactive widgets
-    return tqdm(**tqdm_config)
+    # Use same approach as main progress bar for consistency
+    is_notebook, is_tty, is_windows = _detect_environment()
+    if is_notebook:
+        tqdm_config.pop("colour", None)
+        try:
+            return tqdm_auto(**tqdm_config)
+        except Exception:
+            tqdm_config["ascii"] = True
+            return tqdm_auto(**tqdm_config)
+    else:
+        try:
+            return tqdm(**tqdm_config)
+        except Exception:
+            tqdm_config["ascii"] = True
+            return tqdm(**tqdm_config)
 
 
 def progress_for(iterable: Iterable[Any], desc: str, total: Optional[int] = None, leave: bool = True, **kwargs) -> Iterator[Any]:


### PR DESCRIPTION
### Problem
Table and chart progress bars in Google Colab were displaying at narrow width compared to the main PaddleOCR loading progress bar, creating visual inconsistency.

### Solution
- Unified `create_notebook_friendly_bar()` to use same tqdm implementation as main progress bar
- Applied identical configuration with `dynamic_ncols: True` and `tqdm_auto()`
- Ensured all progress bars display at full width (100 columns)