### PR TITLE
Fix MkDocs asset URLs to resolve CI build issues

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Welcome to Doctra
 
-![Doctra Banner](assets/Doctra_Banner.png)
+![Doctra Banner](https://raw.githubusercontent.com/AdemBoukhris457/Doctra/main/assets/Doctra_Banner.png)
 
 [![PyPI version](https://img.shields.io/pypi/v/doctra)](https://pypi.org/project/doctra/)
 [![Python versions](https://img.shields.io/pypi/pyversions/doctra)](https://pypi.org/project/doctra/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,8 +63,8 @@ theme:
     edit: material/pencil
     view: material/eye
 
-  logo: assets/Doctra_without_background.png
-  favicon: assets/Doctra_without_background.png
+  logo: https://raw.githubusercontent.com/AdemBoukhris457/Doctra/main/assets/Doctra_without_background.png
+  favicon: https://raw.githubusercontent.com/AdemBoukhris457/Doctra/main/assets/Doctra_without_background.png
 
 markdown_extensions:
   - abbr


### PR DESCRIPTION
## 🐛 Problem
GitHub Actions CI was failing with MkDocs strict mode warnings about missing asset files:

## 🔧 Solution
Updated all asset references to use GitHub raw URLs instead of local file paths:

- **Banner Image**: Changed from `assets/Doctra_Banner.png` to GitHub raw URL
- **Logo**: Updated from local `assets/Doctra_without_background.png` to GitHub raw URL  
- **Favicon**: Updated to use same GitHub raw URL as logo

## 📁 Files Changed
- `docs/index.md` - Updated banner image to use GitHub raw URL
- `mkdocs.yml` - Updated logo and favicon to use GitHub raw URLs