### PR TITLE
docs(readme): add Doc Status badge linking to docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy Documentation
+name: Doc Status
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![stars](https://img.shields.io/github/stars/AdemBoukhris457/Doctra.svg)](https://github.com/AdemBoukhris457/Doctra)
 [![forks](https://img.shields.io/github/forks/AdemBoukhris457/Doctra.svg)](https://github.com/AdemBoukhris457/Doctra)
 [![PyPI version](https://img.shields.io/pypi/v/doctra)](https://pypi.org/project/doctra/)
+[![Doc Status](https://github.com/AdemBoukhris457/Doctra/actions/workflows/build-docs.yml/badge.svg)](https://ademboukhris457.github.io/Doctra/)
 </div>
 
 ## 📋 Table of Contents


### PR DESCRIPTION
## Summary

Adds a short **Doc Status** badge to the README and links it to the published documentation site.

## What changed

* Inserted docs status badge under the banner in `README.md`
* Badge points to **[https://ademboukhris457.github.io/Doctra/](https://ademboukhris457.github.io/Doctra/)**

### Badge (before → after)

```md
# Before: no docs badge
```

```md
# After
[![Doc Status](https://github.com/AdemBoukhris457/Doctra/actions/workflows/build-docs.yml/badge.svg)](https://ademboukhris457.github.io/Doctra/)
```